### PR TITLE
fix(find_all_files): cover non-file/directory case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "ms2cc"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms2cc"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,22 +81,21 @@ fn find_all_files(
                 continue;
             }
 
-            if !path.is_file() {
-                let e = format!("{path:?} is not a file");
-                let _ = error_tx.send(e);
+            if path.is_file() {
+                // Normalize the path
+                if let Some(path) =
+                    path.to_str().map(|s| s.to_lowercase()).map(PathBuf::from)
+                {
+                    let _ = entry_tx.send(path);
+                } else {
+                    let e = format!("Failed to normalize {path:?}");
+                    let _ = error_tx.send(e);
+                }
                 continue;
             }
 
-            // Normalize the path
-            if let Some(path) =
-                path.to_str().map(|s| s.to_lowercase()).map(PathBuf::from)
-            {
-                let _ = entry_tx.send(path);
-            } else {
-                let e = format!("Failed to normalize {path:?}");
-                let _ = error_tx.send(e);
-                continue;
-            }
+            let e = format!("Unknown entry {path:?}");
+            let _ = error_tx.send(e);
         }
     }
 }


### PR DESCRIPTION
While building the file tree, it's possible to encounter a non-file
-directory entry.  To detect this, explicitly check if the entry is a
file or a directory.  If neither, log an error indicating an
unrecognized entry was skipped.
