### PR TITLE
fix: try reconstructing path with /Fo and filename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "ms2cc"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms2cc"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Attempting to reconstruct the path using the /Fo argument only
considered the filename from the from the compile command entry in the
log. In some cases, however, a relative path is included in the compile
command entry and we may be able to reconstruct the absolute path from
it.

Consider:

    cl.exe /c /FoC:\\Path\\To\\ObjectFile ..\\src\\main.cpp

Prior to this commit, the components of the /Fo argument were joined
with just main.cpp, ignoring the ..\\src\\ components.

In addition to the original algorithm, the search also tries using
..\\src\\main.cpp with the components of the /Fo argument.
